### PR TITLE
#20 :metal:, Exposed encode with support

### DIFF
--- a/src/Util.py
+++ b/src/Util.py
@@ -9,7 +9,7 @@ def fileContentsToList(fileName):
     lineList = []
 
     try:
-        fileParser = open(fileName, 'r')
+        fileParser = open(fileName, 'r', encoding='latin-1')
 
     except IOError:
         print("[!] Could not open file " + fileName)


### PR DESCRIPTION
Was passed encoding with `latin-1` for wordlist.